### PR TITLE
Refactor HashTable and StringHash; add runtime checks

### DIFF
--- a/HashTable.h
+++ b/HashTable.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <iostream>
 #include <stdexcept>
+#include <cmath>
+#include <string>
 #include "PrimeUtil.h" // for the prime-->getNextPrime method
 
 using namespace std;
@@ -11,7 +13,6 @@ enum tableStatus		// SG
 	TABLE_NOT_FULL,
 	TABLE_FULL
 };
-
 
 enum state
 {
@@ -50,25 +51,13 @@ protected:
 	Item* table;				// The table, specifically a pointer to an array of Items
 	tableStatus status;			// SG tableStatus to hold the status of the table (full or not full) SG
 
-	// methods to track the "fullness" status of the table
-	virtual void setTableStatus(tableStatus stat);		// SG set the table status
-	virtual tableStatus getTableStatus() const;						// SG get the table status
-
 	// pure virtual hash functions
 	virtual int h1(K k) const = 0;
 	virtual int h2(K k) const = 0;
 
-	bool prime(int m) const
-	{
-		// cout << "IF YOU SEE THIS MESSAGE IT MEANS THAT PRIME FUNCTION IS BROKEN" << endl
-		//	 << "change the method in getNextPrime to use PrimeUtil.h's method\n";
-		for (int i = 2; i < (int)sqrt(m); i++)
-			if (m % i == 0)
-				return false;
-		return true;
-	}
-	// can't change PrimeUtil.h, so i'm expanding on it here
-	int getNextPrime(int m) const;
+	// methods to track the "fullness" status of the table
+	virtual void setTableStatus(tableStatus stat);		// SG set the table status
+	virtual tableStatus getTableStatus() const;			// SG get the table status
 
 public:
 	HashTable(int m = 10);
@@ -83,6 +72,18 @@ public:
 	bool remove(K key);
 
 	void print() const;
+
+	bool prime(int m) const
+	{
+		// cout << "IF YOU SEE THIS MESSAGE IT MEANS THAT PRIME FUNCTION IS BROKEN" << endl
+		//	 << "change the method in getNextPrime to use PrimeUtil.h's method\n";
+		for (int i = 2; i < (int)sqrt(m); i++)
+			if (m % i == 0)
+				return false;
+		return true;
+	}
+	// can't change PrimeUtil.h, so i'm expanding on it here
+	int getNextPrime(int m) const;
 };
 
 // implement getNextPrime
@@ -138,7 +139,7 @@ template <class K, class T>
 tableStatus HashTable<K, T>::getTableStatus() const
 {
 	// pretty self explanitory
-	return status;
+	return (tableStatus)status;
 }
 
 template <class K, class T>
@@ -215,6 +216,11 @@ T HashTable<K, T>::search(K key) const
 	do
 	{
 		index = hash(key, collisions);
+		if (index > size)
+		{
+			// avoid accessing out of bounds
+			throw runtime_error("Index out of bounds - failed search");
+		}
 		// if we come accross a cell that has not been touched, aka empty, then we end our search since it can't be past here
 		if (table[index].flag == EMPTY)
 		{
@@ -241,6 +247,11 @@ bool HashTable<K, T>::remove(K key)
 	{
 		// this method uses the same type of searching as search method
 		index = hash(key, collisions);
+		if (index > size)
+		{
+			// avoid accessing out of bounds
+			throw runtime_error("Index out of bounds - failed remove");
+		}
 		if (table[index].flag == EMPTY)
 		{
 			// search landed on empty, nothing beyond, leave

--- a/IntHash.h
+++ b/IntHash.h
@@ -10,7 +10,6 @@ private:
 	{
 		return (k % this->size);
 	}
-
 	int h2(int k) const override
 	{
 		return (1 + (k % (this->size - 1)));

--- a/StringHash.h
+++ b/StringHash.h
@@ -9,6 +9,10 @@ class StringHash : public HashTable<string, T>
 private:
 	int h1(string k) const override
 	{
+		if (k.length() <= 0)
+		{
+			throw runtime_error("Key is empty - failed StringHash::h1");
+		}
 		unsigned long long int hash = 0;
 		for (int i = 0; i < k.length(); ++i)
 		{
@@ -25,8 +29,17 @@ private:
 	}
 	int h2(string k) const override
 	{
+		int length = k.length();
+		if (length <= 0)
+		{
+			throw runtime_error("Key is empty - failed StringHash::h2");
+		}
+		if (length > 8)
+		{
+			throw runtime_error("Key is too long - failed StringHash::h2");
+		}
 		unsigned long long int hash = 0;
-		for (int i = 0; i < k.length(); ++i)
+		for (int i = 0; i < length; ++i)
 		{
 			hash = (hash * 256 + k[i]) % (this->size - 1);
 		}


### PR DESCRIPTION
- Added `#include <cmath>` and `#include <string>` to `HashTable.h`.
- Moved `prime` and 'getNextPrime' methods to public in `HashTable.h`.
- Added error handling in HashTable default constructor in `HashTable.h`.
- Added runtime checks in `search`, `remove`, and 'insert' methods in `HashTable.h`.
- Added runtime checks in `h1` and `h2` methods of `StringHash` class in `StringHash.h`.
- Optimized loop in `h2` method of `StringHash` class to use `length` variable.